### PR TITLE
Fixed ARP spoofing crash

### DIFF
--- a/scapyHunt.py
+++ b/scapyHunt.py
@@ -232,7 +232,7 @@ def arpIsAt(pkt):
   if pkt[ARP].pdst in clients:
     fake_src_mac = clients[pkt[ARP].pdst]
   elif pkt[ARP].pdst in internalClients:
-    fake_src_mac = clients[pkt[ARP].pdst]
+    fake_src_mac = internalClients[pkt[ARP].pdst]
   ether = Ether(dst=pkt.hwsrc, src=fake_src_mac)
   arp = ARP(op="is-at", psrc=pkt.pdst, pdst="10.5.0.1", hwsrc=fake_src_mac, hwdst=pkt.hwsrc)
   rpkt = ether/arp


### PR DESCRIPTION
When trying ARP spoof the script crashed when accessing MAC of 10.1.8.6, fixed it by calling the right function internalClients() on line 235.